### PR TITLE
fix(lexer): 不正な数値を無言で 0.0 にせず Error トークンを返す

### DIFF
--- a/core/src/lexer/mod.rs
+++ b/core/src/lexer/mod.rs
@@ -156,7 +156,7 @@ impl<'a> Lexer<'a> {
         self.input[start..self.pos].to_string()
     }
 
-    fn read_number(&mut self) -> f64 {
+    fn read_number(&mut self) -> TokenKind {
         let start = self.pos;
         while let Some(c) = self.peek() {
             if c.is_ascii_digit() || c == '.' || c == '-' {
@@ -165,7 +165,11 @@ impl<'a> Lexer<'a> {
                 break;
             }
         }
-        self.input[start..self.pos].parse().unwrap_or(0.0)
+        let raw = &self.input[start..self.pos];
+        match raw.parse() {
+            Ok(n) => TokenKind::Number(n),
+            Err(_) => TokenKind::Error(format!("Invalid number: '{}'", raw)),
+        }
     }
 
     fn read_comment(&mut self) -> String {
@@ -262,7 +266,7 @@ impl<'a> Lexer<'a> {
                     self.advance();
                     TokenKind::Arrow
                 } else if self.peek().map(|c| c.is_ascii_digit()).unwrap_or(false) {
-                    TokenKind::Number(self.read_number())
+                    self.read_number()
                 } else {
                     let next_char_is_digit = self.input[self.pos + 1..]
                         .chars()
@@ -270,7 +274,7 @@ impl<'a> Lexer<'a> {
                         .map(|c| c.is_ascii_digit())
                         .unwrap_or(false);
                     if next_char_is_digit {
-                        TokenKind::Number(self.read_number())
+                        self.read_number()
                     } else {
                         self.advance();
                         TokenKind::Identifier("-".to_string())
@@ -313,7 +317,7 @@ impl<'a> Lexer<'a> {
                     TokenKind::Identifier("/".to_string())
                 }
             }
-            _ if c.is_ascii_digit() => TokenKind::Number(self.read_number()),
+            _ if c.is_ascii_digit() => self.read_number(),
             _ if c.is_alphabetic() => {
                 let ident = self.read_identifier();
                 match ident.as_str() {

--- a/core/src/lexer/mod.rs
+++ b/core/src/lexer/mod.rs
@@ -465,6 +465,19 @@ mod tests {
     }
 
     #[test]
+    fn test_invalid_number_is_error() {
+        // "5-3" must not silently become 0.0 (issue #48)
+        for input in ["5-3", "1.2.3"] {
+            let mut lexer = Lexer::new(input);
+            let tokens = lexer.tokenize();
+            match &tokens[0].kind {
+                TokenKind::Error(msg) => assert!(msg.contains("Invalid number")),
+                other => panic!("Expected Error token for '{}', got {:?}", input, other),
+            }
+        }
+    }
+
+    #[test]
     fn test_input_too_large() {
         let input = "a".repeat(100 * 1024 + 1);
         let mut lexer = Lexer::new(&input);


### PR DESCRIPTION
## 概要
Closes #48

`core/src/lexer/mod.rs` の `read_number` は数字・`.`・`-` を貪欲に消費し、`parse().unwrap_or(0.0)` で失敗時に無言で `0.0` を返していた。このためユーザーのタイプミスが構文エラーにならず、意図しない座標で SVG / play 出力が生成されていた。

## 変更内容
- `read_number` の戻り値を `f64` から `TokenKind` に変更し、parse 失敗時に `TokenKind::Error("Invalid number: '...'")` を返すようにした
- 併せて 3 箇所の呼び出し側から `TokenKind::Number(...)` ラッパを除去（呼び出しが簡潔に）
- 不正な数値 (`5-3`, `1.2.3`) を検証するテストを追加

## 動作
```
action = { move = { p1 -> (5-3, 10) } }
```
→ 従来は `(0, 10)` として無言で描画。修正後は `5-3` が `Error` トークンになりユーザーにエラーが伝わる。

## テスト
`cargo test` 全 22 件(lexer crate)パス。新規 `test_invalid_number_is_error` を含む。

🤖 Generated with [Claude Code](https://claude.com/claude-code)