### PR TITLE
fix(formatter): パースエラーを無視せず非ゼロ終了する

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 use clap::{Parser, Subcommand};
 use playbook_lang_core::Renderer;
-use playbook_lang_formatter::format;
+use playbook_lang_formatter::format_checked;
 use playbook_lang_linter::lint;
 use std::fs;
 use std::path::PathBuf;
@@ -68,8 +68,15 @@ fn main() {
         }
         Commands::Fmt { input } => {
             let input_content = fs::read_to_string(&input).expect("Failed to read input file");
-            let formatted = format(&input_content);
-            print!("{}", formatted);
+            match format_checked(&input_content) {
+                Ok(formatted) => print!("{}", formatted),
+                Err(errors) => {
+                    for e in &errors {
+                        eprintln!("{}: parse error: {}", input.display(), e);
+                    }
+                    std::process::exit(1);
+                }
+            }
         }
         Commands::Lint { input } => {
             let input_content = fs::read_to_string(&input).expect("Failed to read input file");

--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -1,12 +1,31 @@
 use crate::ast::*;
 use crate::constants::DEFAULT_BEZIER_CURVE_FACTOR;
 use crate::lexer::{Span, Token, TokenKind};
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum ParseError {
     UnexpectedToken(Token, String),
     UnexpectedEOF,
     InvalidSyntax(Token, String),
+}
+
+impl fmt::Display for ParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParseError::UnexpectedToken(token, msg) => write!(
+                f,
+                "unexpected token at line {}, column {}: {}",
+                token.span.line, token.span.column, msg
+            ),
+            ParseError::UnexpectedEOF => write!(f, "unexpected end of input"),
+            ParseError::InvalidSyntax(token, msg) => write!(
+                f,
+                "invalid syntax at line {}, column {}: {}",
+                token.span.line, token.span.column, msg
+            ),
+        }
+    }
 }
 
 pub struct Parser {

--- a/formatter/src/lib.rs
+++ b/formatter/src/lib.rs
@@ -3,20 +3,30 @@ use playbook_lang_core::ast::{
     State, Timing,
 };
 use playbook_lang_core::lexer::{Lexer, Span};
-use playbook_lang_core::parser::Parser;
+use playbook_lang_core::parser::{ParseError, Parser};
 use std::collections::VecDeque;
 
 use wasm_bindgen::prelude::*;
 
+/// Formats the input. Returns the original input unchanged if there are parse errors.
 #[wasm_bindgen]
 pub fn format(input: &str) -> String {
+    format_checked(input).unwrap_or_else(|_| input.to_string())
+}
+
+/// Formats the input, returning parse errors if any are found.
+pub fn format_checked(input: &str) -> Result<String, Vec<ParseError>> {
     let mut lexer = Lexer::new(input);
     let tokens = lexer.tokenize();
     let mut parser = Parser::new(tokens);
-    let (playbook, _errors) = parser.parse();
+    let (playbook, errors) = parser.parse();
+
+    if !errors.is_empty() {
+        return Err(errors);
+    }
 
     let mut formatter = Formatter::new(playbook);
-    formatter.format()
+    Ok(formatter.format())
 }
 
 struct Formatter {
@@ -340,5 +350,18 @@ action = {
         let first_pass = format(input);
         let second_pass = format(&first_pass);
         assert_eq!(first_pass, second_pass, "Formatting should be idempotent");
+    }
+
+    #[test]
+    fn test_parse_error_handling() {
+        let invalid = "players = { !!!invalid";
+        assert_eq!(format(invalid), invalid);
+        assert!(format_checked(invalid).is_err());
+    }
+
+    #[test]
+    fn test_format_checked_ok_on_valid_input() {
+        let input = "action={move={p1->(10,10)}}";
+        assert!(format_checked(input).is_ok());
     }
 }


### PR DESCRIPTION
## Summary

- `formatter/src/lib.rs` の `format` 関数がパースエラーを破棄し、壊れた AST から整形結果を出力していた問題を修正 (closes #53)
- `format_checked` を追加し、パースエラーがある場合は `Err(Vec<ParseError>)` を返す
- `cli fmt` は `format_checked` を使用し、エラー時はファイル名付きで stderr に出力して exit 1 する
- wasm 向けの `format` はエラー時に元入力をそのまま返す安全なフォールバックに変更
- `ParseError` に `Display` 実装を追加し、行・列番号付きのエラーメッセージを提供

## Test plan

- [ ] `cargo test` がすべてパスすること
- [ ] 正常な `.playbook` ファイルに対して `cli fmt` が整形結果を出力すること
- [ ] 構文エラーのある `.playbook` ファイルに対して `cli fmt` が stderr にエラーを出力し exit 1 すること
- [ ] wasm の `format` が構文エラーのある入力に対して元入力をそのまま返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)