### PR TITLE
fix(parser): カーブ係数の桁数チェック (len > 3) を数値検証に置き換える

### DIFF
--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -457,21 +457,19 @@ impl Parser {
                 let dir_str = parts[0];
                 let factor = if parts.len() > 1 {
                     let factor_str = parts[1];
-                    if factor_str.len() > 3 {
-                        return Err(ParseError::InvalidSyntax(
-                            token.clone(),
-                            format!(
-                                "Curve factor must be at most 3 characters (e.g. 0.5): {}",
-                                factor_str
-                            ),
-                        ));
-                    }
-                    factor_str.parse::<f64>().map_err(|_| {
+                    let value = factor_str.parse::<f64>().map_err(|_| {
                         ParseError::InvalidSyntax(
                             token.clone(),
                             format!("Invalid curve factor: {}", factor_str),
                         )
-                    })?
+                    })?;
+                    if !value.is_finite() {
+                        return Err(ParseError::InvalidSyntax(
+                            token.clone(),
+                            format!("Curve factor must be a finite number: {}", factor_str),
+                        ));
+                    }
+                    value
                 } else {
                     DEFAULT_BEZIER_CURVE_FACTOR
                 };
@@ -819,13 +817,44 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_invalid_curve_factor_length() {
+    fn test_parse_curve_factor_multi_digit_and_negative() {
+        // Values longer than 3 characters (0.25, -0.5) used to be rejected by an
+        // arbitrary byte-length check. They are valid coefficients and must parse.
         let input = r#"
         players = { p1 }
         state = { }
         action = {
             move = {
-                p1 ~[l:0.15]> (10, 10)
+                p1 ~[l:0.25]> (10, 10),
+                p1 ~[r:-0.5]> (20, 20)
+            },
+        }
+        "#;
+        let mut lexer = Lexer::new(input);
+        let tokens = lexer.tokenize();
+        let mut parser = Parser::new(tokens);
+        let (playbook, errors) = parser.parse();
+
+        assert!(errors.is_empty(), "unexpected errors: {:?}", errors);
+
+        match playbook.actions[0].moves[0].path_type {
+            PathType::Curve(CurveDirection::Left(f)) => assert_eq!(f, 0.25),
+            _ => panic!("Expected Left Curve with 0.25"),
+        }
+        match playbook.actions[0].moves[1].path_type {
+            PathType::Curve(CurveDirection::Right(f)) => assert_eq!(f, -0.5),
+            _ => panic!("Expected Right Curve with -0.5"),
+        }
+    }
+
+    #[test]
+    fn test_parse_invalid_curve_factor() {
+        let input = r#"
+        players = { p1 }
+        state = { }
+        action = {
+            move = {
+                p1 ~[l:abc]> (10, 10)
             },
         }
         "#;
@@ -842,9 +871,7 @@ mod tests {
 
         // At least one should be the specific error
         let found = errors.iter().any(|e| match e {
-            ParseError::InvalidSyntax(_, msg) => {
-                msg.contains("Curve factor must be at most 3 characters")
-            }
+            ParseError::InvalidSyntax(_, msg) => msg.contains("Invalid curve factor"),
             _ => false,
         });
         assert!(found);

--- a/linter/src/lib.rs
+++ b/linter/src/lib.rs
@@ -94,14 +94,13 @@ mod tests {
 
     #[test]
     fn test_lint_error_invalid_syntax() {
-        // Curve factor too long triggers InvalidSyntax
-        let input = "players={p1} state={} action={ move={ p1 ~[l:0.1234]> (0,0) } }";
+        // A non-numeric curve factor triggers InvalidSyntax
+        let input = "players={p1} state={} action={ move={ p1 ~[l:abc]> (0,0) } }";
         let diagnostics = lint_playbook_internal(input);
         assert!(!diagnostics.is_empty());
-        let found = diagnostics.iter().any(|d| {
-            d.message
-                .contains("Curve factor must be at most 3 characters")
-        });
+        let found = diagnostics
+            .iter()
+            .any(|d| d.message.contains("Invalid curve factor"));
         assert!(
             found,
             "Expected error message not found in diagnostics: {:?}",


### PR DESCRIPTION
## 概要

Closes #52

`core/src/parser/mod.rs` の `factor_str.len() > 3` によるバイト長チェックは恣意的な制限で、`0.25`（4文字）や負値 `-0.5` などの妥当なカーブ係数を拒否していた（一方 `1.5` は通る、という不整合があった）。

## 変更内容

- 桁数チェック（`len() > 3`）を削除。
- `parse::<f64>()` の成否で検証し、加えて `is_finite()` で NaN / 無限大を拒否する。
  - 値域（例: `0.0..=1.0`）の制限は入れていない。Issue が `-0.5` を妥当な係数として挙げているため、負値も許容する。

### 再現していたケース（修正後は通る）
```
move = { p1 ~[l:0.25]> (10, 10) }
move = { p1 ~[r:-0.5]> (20, 20) }
```

## テスト

- 旧 `test_parse_invalid_curve_factor_length`（`0.15` を長さ超過として拒否することを検証）を削除。
- `test_parse_curve_factor_multi_digit_and_negative` を追加し、`0.25` と `-0.5` が正しくパースされることを検証。
- `test_parse_invalid_curve_factor` を追加し、非数値 `abc` がエラーになることを検証。
- `cargo test --lib` 全 22 件パス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)