### PR TITLE
fix(parser): action 内エラーの span を player トークンに合わせる

### DIFF
--- a/core/src/parser/mod.rs
+++ b/core/src/parser/mod.rs
@@ -106,6 +106,18 @@ impl Parser {
         }
     }
 
+    fn peek_span(&self) -> Span {
+        self.tokens
+            .get(self.pos)
+            .map(|token| token.span)
+            .unwrap_or(Span {
+                start: 0,
+                end: 0,
+                line: 0,
+                column: 0,
+            })
+    }
+
     fn advance(&mut self) -> Token {
         let token = self.peek();
         if self.pos < self.tokens.len() {
@@ -511,6 +523,7 @@ impl Parser {
                             && self.peek().kind != TokenKind::EOF
                         {
                             // Try parsing a move line: player -> target
+                            let span = self.peek_span();
                             match self.expect_identifier() {
                                 Ok(player) => match self.expect_arrow() {
                                     Ok(path_type) => match self.parse_coordinate() {
@@ -519,7 +532,7 @@ impl Parser {
                                                 player,
                                                 target,
                                                 path_type,
-                                                span: self.peek().clone().span,
+                                                span,
                                             });
                                         }
                                         Err(e) => self.error(e),
@@ -546,6 +559,7 @@ impl Parser {
                         while self.peek().kind != TokenKind::RBrace
                             && self.peek().kind != TokenKind::EOF
                         {
+                            let span = self.peek_span();
                             match self.expect_identifier() {
                                 Ok(player) => match self.expect_arrow() {
                                     Ok(path_type) => {
@@ -588,7 +602,7 @@ impl Parser {
                                                     target,
                                                     timing,
                                                     path_type,
-                                                    span: self.peek().clone().span,
+                                                    span,
                                                 });
                                             }
                                             Err(e) => self.error(e),
@@ -616,6 +630,7 @@ impl Parser {
                         while self.peek().kind != TokenKind::RBrace
                             && self.peek().kind != TokenKind::EOF
                         {
+                            let span = self.peek_span();
                             match self.expect_identifier() {
                                 Ok(from) => {
                                     if let Err(e) = self.expect_and_advance(TokenKind::Arrow) {
@@ -647,7 +662,7 @@ impl Parser {
                                                     from,
                                                     to,
                                                     timing,
-                                                    span: self.peek().clone().span,
+                                                    span,
                                                 });
                                             }
                                             Err(e) => self.error(e),
@@ -897,5 +912,20 @@ mod tests {
             _ => false,
         });
         assert!(found);
+    }
+
+    #[test]
+    fn test_action_span_points_to_player_token() {
+        // The player identifier starts at line 4, column 1.
+        // Before the fix, the span pointed at the trailing comma instead.
+        let input = "players = { p1 }\nstate = { position = { p1 = (0, 0) } }\nactions = [ action = { move = {\np1 -> (5, 5),\n} } ]";
+        let mut lexer = Lexer::new(input);
+        let tokens = lexer.tokenize();
+        let mut parser = Parser::new(tokens);
+        let (playbook, _) = parser.parse();
+
+        let span = playbook.actions[0].moves[0].span;
+        assert_eq!(span.line, 4);
+        assert_eq!(span.column, 1);
     }
 }


### PR DESCRIPTION
## 概要

Fixes #50

`core/src/parser/mod.rs` の `parse_action_block` で `MoveAction` / `ScreenAction` / `PassAction` の `span` を、行を読み終えた後の `self.peek().clone().span` で設定していた。このため span は当該プレイヤーではなく **次のトークン**（カンマ・次行・閉じ括弧）を指し、IR エラー位置・linter ハイライト・formatter のコメント対応位置がずれていた。

## 修正

- 行頭の player トークンの span を `expect_identifier()` で消費する前に保持し、各 Action の `span` に設定。
- あわせて `Token` を丸ごとクローンせず `Copy` な `Span` だけを読む `peek_span()` ヘルパを追加（旧 `self.peek().clone().span` は Token をクローンしていた）。

## テスト

- 回帰テスト `test_action_span_points_to_player_token` を追加。player が 4 行 1 列にある入力で span が `line: 4, column: 1`（カンマではなく player）を指すことを検証。
- `cargo test -p playbook_lang_core` → 22 passed / 0 failed。`cargo clippy` / `cargo fmt` クリーン。

## 補足

このブランチは `/simplify`（reuse / simplification / efficiency / altitude の 4 観点レビュー）を通している。efficiency 観点の指摘を反映して `peek_span()` を導入。残りの観点はクリーン判定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)